### PR TITLE
ClearPedTasks

### DIFF
--- a/client/sit.lua
+++ b/client/sit.lua
@@ -140,7 +140,7 @@ local function PlaySit(entity, seatID)
         disabled = true,
         onReleased = function(self)
             lib.hideTextUI()
-            ClearPedTasksImmediately(playerPed)
+            ClearPedTasks(playerPed)
             seatID -= 1
             TriggerServerEvent("melons_mapsutility:server:ModelRegistration", entityNetID, seatID)
             if seatID == 0 then


### PR DESCRIPTION
ClearPedTasksImmediately() often clipped me into benches and overall the lack of an animation made it unsatisfactory. The ClearPedTasks() native made this animation much smoother when getting up from chairs and benches.